### PR TITLE
Fix invalid index name

### DIFF
--- a/tracardi/service/storage/index.py
+++ b/tracardi/service/storage/index.py
@@ -7,7 +7,7 @@ class Index:
         self.multi_index = multi_index
         self.rel = rel
         self.index = index
-        self.prefix = "{}-".format(os.environ['INSTANCE_PREFIX']) if 'INSTANCE_PREFIX' in os.environ else ''
+        self.prefix = "{}-".format(os.environ['INSTANCE_PREFIX']) if 'INSTANCE_PREFIX' in os.environ and not os.environ['INSTANCE_PREFIX'] else ''
         self.mapping = mapping
 
     def _index(self):


### PR DESCRIPTION
When the INSTANCE_PREFIX variable is set, and it's value is empty, then index names start with a dash. These are invalid index names.