### PR TITLE
Add utf-8 encoding to long_description file

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup
 
-with open("README.md", "r") as fh:
+with open("README.md", "r",encoding="utf-8") as fh:
     long_description = fh.read()
 
 


### PR DESCRIPTION
On some devices, when I try to install dependencies, I got a Unicode Error.

>pip install -r app\\requirements.txt
Collecting git+https://github.com/Tracardi/tracardi.git@master (from -r app\\requirements.txt (line 14))
  Cloning https://github.com/Tracardi/tracardi.git (to revision master) to c:\users\admin\appdata\local\temp\pip-req-build-iiw0mxc1
  Running command git clone --filter=blob:none --quiet https://github.com/Tracardi/tracardi.git 'C:\Users\admin\AppData\Local\Temp\pip-req-build-iiw0mxc1'
  Resolved https://github.com/Tracardi/tracardi.git to commit 2d03555be4fc8a327ce1ef1573790f00246609cd
  Preparing metadata (setup.py) ... error
  error: subprocess-exited-with-error
  python setup.py egg_info did not run successfully.
  │ exit code: 1
  ╰─> [8 lines of output]
      Traceback (most recent call last):
        File "<string>", line 2, in <module>
        File "<pip-setuptools-caller>", line 34, in <module>
        File "C:\Users\admin\AppData\Local\Temp\pip-req-build-iiw0mxc1\setup.py", line 4, in <module>
          long_description = fh.read()
        File "C:\Program Files\WindowsApps\PythonSoftwareFoundation.Python.3.9_3.9.3568.0_x64__qbz5n2kfra8p0\lib\encodings\cp1250.py", line 23, in decode
          return codecs.charmap_decode(input,self.errors,decoding_table)[0]
      UnicodeDecodeError: 'charmap' codec can't decode byte 0x90 in position 451: character maps to <undefined>
      [end of output]

PRs without ticked MIT license will not be accepted - Sorry.