### PR TITLE
create resend.com plugin template

### DIFF
--- a/tracardi/domain/resources/resend.py
+++ b/tracardi/domain/resources/resend.py
@@ -1,0 +1,5 @@
+from pydantic import BaseModel
+
+
+class ResendResource(BaseModel):
+    api_key: str

--- a/tracardi/process_engine/action/v1/connectors/resend/README.md
+++ b/tracardi/process_engine/action/v1/connectors/resend/README.md
@@ -1,0 +1,45 @@
+## send email api
+
+url: POST https://api.resend.com/emails
+
+```shell
+curl -X POST 'https://api.resend.com/emails' \
+     -H 'Authorization: Bearer re_123456789' \
+     -H 'Content-Type: application/json' \
+     -d $'{
+  "from": "Acme <onboarding@resend.dev>",
+  "to": ["delivered@resend.dev"],
+  "subject": "hello world",
+  "text": "it works!",
+  "headers": {
+    "X-Entity-Ref-ID": "123"
+  },
+  "attachments": [
+    {
+      "filename": 'invoice.pdf',
+      "content": invoiceBuffer,
+    },
+  ]
+}'
+```
+
+| params              | type             | required |
+|---------------------|------------------|----------|
+| from                | str              | True     |
+| to                  | str or str[]     | True     |
+| subject             | str              | True     |
+| bcc                 | str or str[]     | False    | 
+| cc                  | str or str[]     | False    | 
+| reply_to            | str or str[]     | False    | 
+| html                | str              | False    | 
+| text                | str              | False    | 
+| react               | str              | False    | 
+| headers             | dict             | False    | 
+| attachments         | list[attachment] | False    | 
+| attachment.content  | buffer or str    | False    | 
+| attachment.filename | str              | False    | 
+| attachment.path     | str              | False    | 
+| tags                | list[tag]        | False    | 
+| tag.name            | str              | True     |
+| value               | str              | False    | 
+

--- a/tracardi/process_engine/action/v1/connectors/resend/send_email/plugin.py
+++ b/tracardi/process_engine/action/v1/connectors/resend/send_email/plugin.py
@@ -1,0 +1,86 @@
+import aiohttp
+from aiohttp import ContentTypeError
+from json import JSONDecodeError
+from tracardi.domain.named_entity import NamedEntity
+from tracardi.domain.resources.resend import ResendResource
+from tracardi.service.tracardi_http_client import HttpClient
+from tracardi.service.storage.driver.elastic import resource as resource_db
+from tracardi.service.plugin.domain.config import PluginConfig
+from tracardi.service.plugin.domain.result import Result
+from tracardi.service.plugin.runner import ActionRunner
+from typing import Any, Union, Optional
+from pydantic import BaseModel
+
+
+class SendEmailParams(BaseModel):
+    sender: str
+    to: Union[str, list[str]]
+    subject: str
+    bcc: Optional[Union[str, list[str]]] = None
+    cc: Optional[Union[str, list[str]]] = None
+    reply_to: Optional[Union[str, list[str]]] = None
+    message: dict
+    headers: Optional[dict[str, Any]] = None
+    attachments: Optional[Any] = None
+    tags: Optional[Any] = None
+
+
+class Config(PluginConfig):
+    resource: NamedEntity
+    params: SendEmailParams
+
+
+def validate(config: dict) -> Config:
+    return Config(**config)
+
+
+class ResendSendEmailAction(ActionRunner):
+    credentials: ResendResource
+    config: SendEmailParams
+
+    async def set_up(self, init):
+        config = validate(init)
+        resource = await resource_db.load(config.resource.id)
+
+        self.config = config.params
+        self.credentials: "ResendResource" = resource.credentials.get_credentials(self, output=ResendResource)
+
+    async def run(self, payload: dict, in_edge=None) -> Result:
+        url = f"https://api.resend.com/emails"
+        params = {
+            "from": self.config.sender,
+            "to": self.config.to,
+            "subject": self.config.subject,
+            "bcc": self.config.bcc,
+            "cc": self.config.cc,
+            "reply_to": self.config.reply_to,
+            "headers": self.config.headers
+        }
+        if self.config.message.get("type", None) == "text/html":
+            params["html"] = self.config.message.get("content", "")
+        else:
+            params["text"] = self.config.message.get("content", "")
+
+        timeout = aiohttp.ClientTimeout(total=2)
+        async with HttpClient(0, [200, 201, 202, 203], timeout=timeout) as client:
+            async with client.post(
+                url=url,
+                json=params,
+                headers={"Authorization": f"Bearer {self.credentials.api_key}"},
+            ) as response:
+                try:
+                    content = await response.json()
+                except ContentTypeError:
+                    content = await response.text()
+                except JSONDecodeError:
+                    content = await response.text()
+
+                result = {
+                    "status": response.status,
+                    "content": content
+                }
+
+                if response.status in [200, 201, 202, 203]:
+                    return Result(port="response", value=result)
+                else:
+                    return Result(port="error", value=result)

--- a/tracardi/process_engine/action/v1/connectors/resend/send_email/registry.py
+++ b/tracardi/process_engine/action/v1/connectors/resend/send_email/registry.py
@@ -1,0 +1,116 @@
+from tracardi.process_engine.action.v1.connectors.resend.send_email.plugin import ResendSendEmailAction
+from tracardi.service.plugin.domain.register import Plugin, Spec, Form, FormGroup, FormField, FormComponent, MetaData, \
+    Documentation, PortDoc
+
+
+def register() -> Plugin:
+    return Plugin(
+        start=False,
+        spec=Spec(
+            module='tracardi.process_engine.action.v1.connectors.resend.send_email.plugin',
+            className=ResendSendEmailAction.__name__,
+            inputs=['payload'],
+            outputs=['response', 'error'],
+            version="0.8.2",
+            license="MIT",
+            author="RyomaHan(ryomahan1996@gmail.com)",
+            init={
+                "resource": {
+                    "id": "",
+                    "name": ""
+                },
+                "params": {},
+            },
+            form=Form(
+                groups=[
+                    FormGroup(
+                        fields=[
+                            FormField(
+                                id="resource",
+                                name="Resend Resource",
+                                required=True,
+                                description="Select Resend Resource.",
+                                component=FormComponent(type="resource", props={"label": "Resend Resource", "tag": "resend"})
+                            ),
+                        ]
+                    ),
+                    FormGroup(
+                        name="Resend Send Email API Params",
+                        fields=[
+                            FormField(
+                                id="params.sender",
+                                name="Sender Email Address",
+                                required=True,
+                                description="To include a friendly name, use the format \"Your Name <sender@domain.com>\".",
+                                component=FormComponent(type="dotPath", props={"label": "Resend"})
+                            ),
+                            FormField(
+                                id="params.to",
+                                name="Recipient Email Address(es)",
+                                required=True,
+                                description="Recipient email address. For multiple addresses, send as an array of strings, such as: [recipient@domain.com,...]. Max 50.",
+                                component=FormComponent(type="dotPath", props={"label": "Resend"})
+                            ),
+                            FormField(
+                                id="params.subject",
+                                name="Email Subject",
+                                required=True,
+                                component=FormComponent(type="dotPath", props={"label": "Resend"})
+                            ),
+                            FormField(
+                                id="params.bcc",
+                                name="Bcc Recipient Email Address",
+                                description="Bcc recipient email address. For multiple addresses, send as an array of strings, such as: [bcc@domain.com,...].",
+                                component=FormComponent(type="dotPath", props={"label": "Resend"})
+                            ),
+                            FormField(
+                                id="params.cc",
+                                name="Cc Recipient Email Address",
+                                description="Cc recipient email address. For multiple addresses, send as an array of strings, such as: [cc@domain.com,...].",
+                                component=FormComponent(type="dotPath", props={"label": "Resend"})
+                            ),
+                            FormField(
+                                id="params.reply_to",
+                                name="Reply-to Email Address",
+                                description="Reply-to email address. For multiple addresses, send as an array of strings, such as: [reply_to@domain.com,...].",
+                                component=FormComponent(type="dotPath", props={"label": "Resend"})
+                            ),
+                            FormField(
+                                id="params.message",
+                                name="Message",
+                                description="The HTML version of the message or the plain text version of the message.",
+                                component=FormComponent(
+                                    type="contentInput",
+                                    props={
+                                        "rows": 13,
+                                        "label": "Message body",
+                                        "allowedTypes": ["text/plain", "text/html"]
+                                    })
+                            ),
+                            FormField(
+                                id="params.headers",
+                                name="Custom Headers",
+                                description="Custom headers to add to the email.",
+                                component=FormComponent(type="dotPath", props={"label": "Resend"})
+                            ),
+                        ]
+                    ),
+                ]
+            )
+        ),
+        metadata=MetaData(
+            name="Resend: Send Email",
+            desc="Send email(s) by Resend.",
+            brand="Resend",
+            icon="resend",
+            group=["Resend"],
+            documentation=Documentation(
+                inputs={
+                    "payload": PortDoc(desc="This port takes payload object.")
+                },
+                outputs={
+                    "response": PortDoc(desc="This port returns response status and content."),
+                    "error": PortDoc(desc="This port returns error if request will fail ")}
+            )
+        )
+    )

--- a/tracardi/service/setup/setup_plugins.py
+++ b/tracardi/service/setup/setup_plugins.py
@@ -63,6 +63,15 @@ installed_plugins: Dict[str, PluginMetadata] = {
         test=PluginTest(init=None, resource=None),
     ),
 
+    "tracardi.process_engine.action.v1.connectors.resend.send_email.plugin": PluginMetadata(
+        test=PluginTest(
+            init={'resource': {'id': 'id', 'name': 'name'}, 'message': 'test'},
+            resource={
+                "api_key": "api_key",
+            }),
+        plugin_registry="tracardi.process_engine.action.v1.connectors.resend.send_email.registry"
+    ),
+
     "tracardi.process_engine.action.v1.connectors.telegram.post.plugin": PluginMetadata(
         test=PluginTest(
             init={'resource': {'id': 'id', 'name': 'name'}, 'message': 'test'},

--- a/tracardi/service/setup/setup_resources.py
+++ b/tracardi/service/setup/setup_resources.py
@@ -75,6 +75,14 @@ def get_resource_types() -> List[ResourceSettings]:
             }
         ),
         ResourceSettings(
+            id="resend",
+            name="Resend",
+            tags=["resend"],
+            config={
+                "api_key": "<api-key>",
+            },
+        ),
+        ResourceSettings(
             id="telegram",
             name="Telegram",
             tags=["telegram"],


### PR DESCRIPTION

 - [x] I hereby declare this contribution to be licenced under the [MIT license](https://opensource.org/licenses/MIT)

@atompie There is a resend.com plugin demo.

 You can test with the plugin named `Resend: Send Email`, and this plugin is implemented for [send email API](https://resend.com/docs/api-reference/emails/send-email).

Could you please review this code to see if there are any issues with the coding logic. 

![image](https://github.com/Tracardi/tracardi/assets/18721016/bc47e2ec-fe8c-4ec4-b1d6-bd356ef25fa6)
