### PR TITLE
Add dot notation to URL on HTML fetcher plugin

### DIFF
--- a/tracardi/process_engine/action/v1/connectors/html/fetch/plugin.py
+++ b/tracardi/process_engine/action/v1/connectors/html/fetch/plugin.py
@@ -55,7 +55,7 @@ class HtmlPageFetchAction(ActionRunner):
 
                 async with client.request(
                         method=self.config.method,
-                        url=str(self.config.url),
+                        url=str(dot[self.config.url]),
                         headers=headers,
                         cookies=cookies,
                         ssl=self.config.ssl_check,


### PR DESCRIPTION

Add dot notation to URL on HTML fetcher plugin ([#882](https://github.com/Tracardi/tracardi/issues/882))

This request will add dot notation to URL.

This code has been tested against 1.0.x

I hereby declare this contribution to be licensed under the [MIT license](https://opensource.org/licenses/MIT).
