### PR TITLE
Delete Segment Plugin: Support name extraction from payload

### DIFF
--- a/tracardi/process_engine/action/v1/segmentation/delete/plugin.py
+++ b/tracardi/process_engine/action/v1/segmentation/delete/plugin.py
@@ -37,7 +37,7 @@ class DeleteSegmentAction(ActionRunner):
         self.config = validate(init)
 
     async def run(self, payload: dict, in_edge=None) -> Result:
-        if isinstance(self.profile, Profile):            
+        if isinstance(self.profile, Profile):
             dot = self._get_dot_accessor(payload)
             profile = Profile(**dot.profile)
             

--- a/tracardi/process_engine/action/v1/segmentation/delete/plugin.py
+++ b/tracardi/process_engine/action/v1/segmentation/delete/plugin.py
@@ -1,8 +1,12 @@
+from tracardi.process_engine.action.v1.segmentation.service.profile_segmentation_services import remove_segment_from_profile
 from tracardi.service.utils.date import now_in_utc
+
+from typing import List, Union
 
 from pydantic import field_validator
 
 from tracardi.domain.profile import Profile
+from tracardi.service.notation.dict_traverser import DictTraverser
 from tracardi.service.plugin.domain.config import PluginConfig
 
 from tracardi.service.plugin.domain.register import Plugin, Spec, MetaData, Documentation, PortDoc, Form, FormGroup, \
@@ -12,12 +16,12 @@ from tracardi.service.plugin.domain.result import Result
 
 
 class Configuration(PluginConfig):
-    segment: str
+    segment: Union[str, List[str]]
 
     @field_validator("segment")
     @classmethod
     def is_not_empty(cls, value):
-        if value == "":
+        if not value:
             raise ValueError("Segment cannot be empty")
         return value
 
@@ -33,14 +37,25 @@ class DeleteSegmentAction(ActionRunner):
         self.config = validate(init)
 
     async def run(self, payload: dict, in_edge=None) -> Result:
-        if isinstance(self.profile, Profile):
+        if isinstance(self.profile, Profile):            
             dot = self._get_dot_accessor(payload)
             profile = Profile(**dot.profile)
-            if self.config.segment in self.profile.segments:
-                profile.metadata.time.segmentation = now_in_utc()
+            
+            profile.metadata.time.segmentation = now_in_utc()
 
-                profile.segments = list(set(profile.segments))
-                profile.segments.remove(self.config.segment)
+            try:
+                if isinstance(self.config.segment, (list, str)):
+                    converter = DictTraverser(dot, include_none=False)
+                    segments = converter.reshape(self.config.segment)
+                    remove_segment_from_profile(profile, segments)
+                else:
+                    return Result(value={
+                        "message": "Not acceptable segmentation type. "
+                                    "Allowed type: string or list of strings"},
+                        port="error")
+            except KeyError as e:
+                return Result(value={"message": str(e)}, port="error")
+
             self.profile.replace(profile)
         else:
             if self.event.metadata.profile_less is True:
@@ -58,8 +73,8 @@ def register() -> Plugin:
             module=__name__,
             className='DeleteSegmentAction',
             inputs=["payload"],
-            outputs=["payload"],
-            version="0.8.1",
+            outputs=["payload", "error"],
+            version="0.9.0",
             author="Risto Kowaczewski",
             manual="segmentation/delete_segment_action",
             init={
@@ -73,7 +88,7 @@ def register() -> Plugin:
                             id="segment",
                             name="Segment name",
                             description="Please type segment name.",
-                            component=FormComponent(type="text", props={"label": "Segment name"})
+                            component=FormComponent(type="dotPath", props={"label": "Segment name"})
                         )
                     ]
                 )]

--- a/tracardi/process_engine/action/v1/segmentation/service/profile_segmentation_services.py
+++ b/tracardi/process_engine/action/v1/segmentation/service/profile_segmentation_services.py
@@ -12,3 +12,18 @@ def add_segment_to_profile(profile: Profile, segments: Union[List[str], str]) ->
         profile.segments.append(segments)
 
     return profile
+
+
+def remove_segment_from_profile(profile: Profile, segments: Union[List[str], str]) -> Profile:
+    if isinstance(segments, list):
+        for segment in segments:
+            if segment in profile.segments:
+                profile.segments = list(set(profile.segments))
+                profile.segments.remove(segment)
+
+    elif isinstance(segments, str):
+        if segments in profile.segments:
+            profile.segments = list(set(profile.segments))
+            profile.segments.remove(segments)
+
+    return profile


### PR DESCRIPTION
Delete segment plugin: segment name dot accessor

Plugin: Delete segment
Bumped plugin version to 0.9.0 (minor)

I added payload dot accessor logic as same as what was in Add Segment plugin to dynamically delete segments by the properties in incoming payload.

Delete Segment Plugin: Support name extraction from payload (#894)

----

**Please** following this checklist to help us incorporate your contribution quickly and easily:

 - [x] Give the same name to the pull request as the name of ticket 
 - [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
 - [x] Test your code throughly before PR.

 - [x] I hereby declare this contribution to be licenced under the [MIT license](https://opensource.org/licenses/MIT)