### PR TITLE
Bump pip to 26.0

### DIFF
--- a/tracardi/requirements.txt
+++ b/tracardi/requirements.txt
@@ -14,7 +14,7 @@ dateparser
 git+https://github.com/Tracardi/dotty_dict@master
 pytz
 device_detector==5.0.1
-pip>=21.2.4
+pip==26.0
 deepdiff==6.2.2
 pytimeparse
 barcodenumber


### PR DESCRIPTION
Noticed some outdated dependencies with known CVEs:

- `pip` 25.3 -> 26.0 (CVE-2026-1703)

Bumped each one to the minimum safe version.