### PR TITLE
Bump requests to 2.33.0

### DIFF
--- a/tracardi/requirements.txt
+++ b/tracardi/requirements.txt
@@ -63,7 +63,7 @@ geopy
 
 # Worker requirements
 mysql-connector-python==8.0.29
-requests
+requests==2.33.0
 
 # Com requirements
 huey


### PR DESCRIPTION
These packages have security fixes available:

- `requests` 2.32.5 -> 2.33.0 (CVE-2026-25645)

Bumped each one to the minimum safe version.