### PR TITLE
Allow None in validate_list_values (fixes merger crash on cleared fields)

### DIFF
--- a/test/unit/test_merger.py
+++ b/test/unit/test_merger.py
@@ -1,8 +1,11 @@
 from datetime import datetime, timedelta
 
+import pytest
+
 from tracardi.domain.consent_revoke import ConsentRevoke
 from tracardi.service.merging.merger import (merge as dict_merge, list_merge, get_conflicted_values,
-                                             get_added_values, get_changed_values, MergingStrategy)
+                                             get_added_values, get_changed_values, MergingStrategy,
+                                             validate_list_values)
 
 
 def test_merger():
@@ -268,3 +271,37 @@ def test_override_strings():
                                         no_single_value_list=True,
                                         default_string_strategy="override"))
     assert result == {"d": "a"}
+
+
+def test_validate_list_values_accepts_scalars():
+    # Plain scalars are accepted and the function returns None on success.
+    assert validate_list_values(["a", 1, 2.5, True]) is None
+
+
+def test_validate_list_values_accepts_none():
+    # `None` is a legitimate value inside `metadata.fields` `[ts, value]`
+    # tuples when a versioned field was cleared (e.g. `traits.lastFcmToken`
+    # on logout). Rejecting it here breaks profile merging for every
+    # profile that ever had a null-valued versioned field.
+    assert validate_list_values([1776420649.007557, None]) is None
+    assert validate_list_values([None, None]) is None
+
+
+def test_validate_list_values_rejects_non_scalars():
+    # Dicts and nested lists still raise.
+    with pytest.raises(ValueError):
+        validate_list_values([1, {"a": 1}])
+    with pytest.raises(ValueError):
+        validate_list_values([1, ["nested"]])
+
+
+def test_merge_handles_metadata_fields_null_tuple():
+    # End-to-end: a `metadata.fields`-shaped `[timestamp, None]` tuple must
+    # survive dict_merge without raising. Before the fix, this path reached
+    # `validate_list_values` and raised ValueError, which bricked profile
+    # merging on any previously-cleared versioned field.
+    dict_1 = {"metadata": {"fields": {"traits.lastFcmToken": [1776420649.007557, None]}}}
+    dict_2 = {"metadata": {"fields": {"traits.lastFcmToken": [1776420700.0, "new-token"]}}}
+    # Should not raise.
+    result = dict_merge(dict_1, [dict_2], MergingStrategy())
+    assert "traits.lastFcmToken" in result["metadata"]["fields"]

--- a/tracardi/service/merging/merger.py
+++ b/tracardi/service/merging/merger.py
@@ -23,8 +23,14 @@ class FieldMergingStrategy(BaseModel):
 
 
 def validate_list_values(values):
+    # `None` is a legitimate value inside Tracardi's own `metadata.fields`
+    # tracker, which stores `[timestamp, value]` tuples. A versioned field
+    # that was cleared (e.g. `traits.lastFcmToken` on logout, or a pre-KYC
+    # `traits.kycProvider`) is represented as `[ts, None]`. Rejecting it
+    # here bricks profile merging for every profile that ever had a
+    # null-valued versioned field.
     for value in values:
-        if not isinstance(value, (str, int, float, bool)):
+        if value is not None and not isinstance(value, (str, int, float, bool)):
             raise ValueError("Invalid value in list `{}`".format(values))
 
 


### PR DESCRIPTION
Fixes #904.

## Problem

`validate_list_values()` in `tracardi/service/merging/merger.py:25` rejects `None`, but `metadata.fields` legitimately stores `[timestamp, None]` tuples when a versioned field is cleared. This breaks profile merging for any profile that ever had a null-valued versioned field — APM's `_deduplicate` raises `ValueError: Invalid value in list [<timestamp>, None]` and retries the same profile every cycle, logging forever.

See the linked issue for a full reproduction + impact numbers (19 profiles / ~500 MB/hour log growth on our staging).

## Fix

One condition: `if value is not None and not isinstance(value, (str, int, float, bool))`.

Consistent with how the rest of the merger treats `None` — existing tests at `test/unit/test_merger.py:14-32` already assert `dict_merge` preserves `None` values, and `test_merger.py:261` already asserts `[None, "d"]` is a valid merge output. `validate_list_values` was the outlier.

## Tests added

In `test/unit/test_merger.py`:

- `test_validate_list_values_accepts_scalars` — unchanged happy path.
- `test_validate_list_values_accepts_none` — the fix. Covers `[float, None]` (the shape from `metadata.fields`) and `[None, None]`.
- `test_validate_list_values_rejects_non_scalars` — regression guard: dicts and nested lists still raise.
- `test_merge_handles_metadata_fields_null_tuple` — end-to-end `dict_merge` on a `metadata.fields`-shaped input.

All four pass against Tracardi 1.1.6 / APM 1.1.27 on our staging.

## Scope

Targeting `1.1.x` (default branch, matches our prod images). The same file+line exists unchanged on `1.2.x` and `2.0.x`; happy to port after review.

## Other branches

Same bug is present on `1.2.x` and `2.0.x` branches (same file, identical function). Happy to open ports to those branches after this one lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)